### PR TITLE
Bump rnaseqmut to 1.1a — GCC compatibility, demo fail-fast, and Python regex fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ We thank Chenfei Wang and Robert K. Bradley for their help and feedback.
 #     Version History
 ----------------------------------------------
 
+- 03/01/2026    1.1a
+  * Update CLI-reported rnaseqmut version to 1.1a.
+  * Improve compatibility with modern GCC/libstdc++ and make demo execution fail-fast when rnaseqmut is missing.
+  * Clean demo script output by fixing Python regex escape warnings.
+- 03/01/2026    1.0
+  * Define 1.0 as the current GitHub baseline release version.
+
 - 08/06/2021
   * Add support to additional characters in CIGAR including soft clipping (S), P, = , H; and fix a corresponding bug to report -1 in position.
   * Add Automatic build and Docker support.
@@ -317,5 +324,4 @@ We thank Chenfei Wang and Robert K. Bradley for their help and feedback.
   * By default, suppress mutations with character "N" (controlled by -n option in rnaseqmut)
 - 09/12/2013	0.1	
   * rnaseqmut software initiated.
-
 

--- a/demo/rundemo.sh
+++ b/demo/rundemo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # This demo illustrates the basic usage of rnaseqmut, including calling de-novo mutations, merging mutations from different samples, calling mutations based on a given list of mutations, and filtering mutations.
 
@@ -23,6 +24,19 @@ cd $CURRENTPATH
 export PATH=$BASEPATH/bin:$PATH
 # add script directory to the PATH
 export PATH=$BASEPATH/script:$PATH
+
+if ! command -v rnaseqmut >/dev/null 2>&1; then
+  if [ -x "$BASEPATH/bin/rnaseqmut.linux.x64" ]; then
+    ln -sf "$BASEPATH/bin/rnaseqmut.linux.x64" "$BASEPATH/bin/rnaseqmut"
+  elif [ -x "$BASEPATH/bin/rnaseqmut.macos.x64" ]; then
+    ln -sf "$BASEPATH/bin/rnaseqmut.macos.x64" "$BASEPATH/bin/rnaseqmut"
+  fi
+fi
+
+if ! command -v rnaseqmut >/dev/null 2>&1; then
+  echo "ERROR: rnaseqmut binary is not available. Compile from source or add bin/rnaseqmut to PATH."
+  exit 1
+fi
 
 ####################
 # step 0, cleaning
@@ -88,5 +102,4 @@ eval $CMD
 
  
 echo ""
-echo "####### DEMO completed succesfully.  Check results/ALLMUT_FILTERED.vcf for detected mutations.  ##########"
-
+echo "####### DEMO completed successfully. Check results/ALLMUT_FILTERED.vcf for detected mutations. ##########"

--- a/script/filtermut.py
+++ b/script/filtermut.py
@@ -38,7 +38,7 @@ regionstart=0;
 regionend=0;
 if args.region is not None:
   hasregion=True;
-  rgpattern=re.findall('(\w+):(\d+)-(\d+)',args.region);
+  rgpattern=re.findall(r'(\w+):(\d+)-(\d+)',args.region);
   if len(rgpattern)==0:
     print('Error: unknown region '+args.region,file=sys.stderr);
     sys.exit(-1);

--- a/script/merge2ndvcf.py
+++ b/script/merge2ndvcf.py
@@ -37,7 +37,7 @@ regionstart=0;
 regionend=0;
 if args.region is not None:
   hasregion=True;
-  rgpattern=re.findall('(\w+):(\d+)-(\d+)',args.region);
+  rgpattern=re.findall(r'(\w+):(\d+)-(\d+)',args.region);
   if len(rgpattern)==0:
     print('Error: unknown region '+args.region,file=sys.stderr);
     sys.exit(-1);

--- a/src/bamtools/src/api/algorithms/Sort.h
+++ b/src/bamtools/src/api/algorithms/Sort.h
@@ -89,7 +89,7 @@ struct API_EXPORT Sort
         {}
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs)
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const
         {
             return sort_helper(m_order, lhs.Name, rhs.Name);
         }
@@ -130,7 +130,7 @@ struct API_EXPORT Sort
         {}
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs)
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const
         {
 
             // force unmapped aligmnents to end
@@ -182,7 +182,7 @@ struct API_EXPORT Sort
         {}
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs)
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const
         {
 
             // force alignments without tag to end

--- a/src/bamtools/src/api/internal/bam/BamMultiMerger_p.h
+++ b/src/bamtools/src/api/internal/bam/BamMultiMerger_p.h
@@ -62,7 +62,7 @@ public:
         : m_comp(comp)
     {}
 
-    bool operator()(const MergeItem& lhs, const MergeItem& rhs)
+    bool operator()(const MergeItem& lhs, const MergeItem& rhs) const
     {
         const BamAlignment& l = *lhs.Alignment;
         const BamAlignment& r = *rhs.Alignment;

--- a/src/parseargs.cpp
+++ b/src/parseargs.cpp
@@ -11,7 +11,7 @@ using namespace TCLAP;
 /* parsing arguments */
 int parseArguments(int argc, char* argv[],CallingArgs& args){
   try{
-    CmdLine cmd("Calling mutations in BAM file.",' ',"0.6");
+    CmdLine cmd("Calling mutations in BAM file.",' ',"1.1a");
     
     ValueArg<int> mutspanarg("m","mut_span","The minimum distance of the mutation to the beginning (end) of the read. Default 4.",false,4,"mut_span");
     cmd.add(mutspanarg);
@@ -80,5 +80,4 @@ int parseArguments(int argc, char* argv[],CallingArgs& args){
   }
   return 0;
 }
-
 


### PR DESCRIPTION
### Motivation
- Update the packaged rnaseqmut release metadata and modernize code to build cleanly with recent compilers and runtime environments.
- Make the demo executable more robust by failing early when the `rnaseqmut` binary is not available and by enforcing strict shell options.
- Remove Python regex escape warnings and minor README/text fixes for clarity.

### Description
- Bumped CLI/reported version string to `1.1a` and added a `1.0` baseline entry in `README.md` version history.
- Marked comparator function call operators as `const` in several bamtools sources (`Sort.h` and `BamMultiMerger_p.h`) to improve compatibility with modern C++ compilers and fix related compile issues.
- Added `set -euo pipefail` to `demo/rundemo.sh`, added logic to create a symlink to an available platform binary when possible, added a fail-fast check that prints an error and exits if `rnaseqmut` is missing, and fixed a typo in the completion message.
- Switched to raw string regex literals in `script/filtermut.py` and `script/merge2ndvcf.py` (e.g. `re.findall(r'(...)', ...)`) to eliminate Python regex escape warnings.
- Minor whitespace/formatting cleanups in `parseargs.cpp` and other script headers.

### Testing
- Built the C++ sources (including updated bamtools portions) with a modern GCC toolchain; the build completed successfully.
- Executed the demo script `demo/rundemo.sh` in an environment with the `rnaseqmut` binary available to verify end-to-end behavior and observed successful completion when binaries are present and immediate failure with a clear error when missing.
- Ran Python scripts (`merge2ndvcf.py` and `filtermut.py`) on sample input to confirm no regex warnings are emitted and that output format remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab067768832994e16968aa06ec08)